### PR TITLE
Pass sudo option to arpscan

### DIFF
--- a/lib/macwatch.js
+++ b/lib/macwatch.js
@@ -15,7 +15,8 @@ var DEFAULTS = {
     interval: 100,
     // goneAfter: 30 * 1000,
     goneAfter: 5 * 60 * 1000,
-    command: onStateChanged
+    command: onStateChanged,
+    sudo: false
 };
 
 var macTargets = {};
@@ -107,6 +108,7 @@ function Macwatch(options){
     scanOptions = {
       verbose: options.verbose,
       interface: options.interface,
+      sudo: options.sudo
     }
     scan();
 


### PR DESCRIPTION
This commit passes the `sudo` option to macscan, e.g. for environments where the arp-scan command is specifically whitelisted in the sudoers file.